### PR TITLE
Improve Healthchecking for MySQL and Files

### DIFF
--- a/.env
+++ b/.env
@@ -3,8 +3,8 @@ MYSQL_PASSWORD=p@ssw0rd1
 MYSQL_PORT=3307
 
 # Double check with data.ppy.sh if it exists.
-DB_URL=https://data.ppy.sh/2023_07_01_performance_catch_top_1000.tar.bz2
-FILES_URL=https://data.ppy.sh/2023_07_01_osu_files.tar.bz2
+DB_URL=https://data.ppy.sh/2023_08_01_performance_catch_top_1000.tar.bz2
+FILES_URL=https://data.ppy.sh/2023_08_01_osu_files.tar.bz2
 
 # Sorted By File Size, Largest First. 0 to exclude, 1 to include.
 # beatmap_id,mode,mods,attrib_id,value

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       dockerfile: osu.mysql.dl.Dockerfile
       args:
         - DB_URL=${DB_URL}
-        - CACHE_DIR=/var/cache/osu.mysql.dl/
+        - CACHE_DIR=/var/lib/osu/osu.mysql
         - OSU_BEATMAP_DIFFICULTY=${OSU_BEATMAP_DIFFICULTY}
         - OSU_BEATMAPS=${OSU_BEATMAPS}
         - OSU_BEATMAPSETS=${OSU_BEATMAPSETS}
@@ -24,8 +24,8 @@ services:
         - OSU_USER_BEATMAP_PLAYCOUNT=${OSU_USER_BEATMAP_PLAYCOUNT}
         - SAMPLE_USERS=${SAMPLE_USERS}
     volumes:
-      - osu.mysql.vol:/var/cache/osu.mysql
-      - osu.mysql.dl.vol:/var/cache/osu.mysql.dl
+      - osu.mysql.init.vol:/var/lib/osu/osu.mysql.init
+      - /var/lib/osu/osu.mysql:/var/lib/osu/osu.mysql
 
   # Uses files from osu.mysql to initialize our mysql database
   osu.mysql:
@@ -36,16 +36,17 @@ services:
       - MYSQL_DATABASE=osu
       - MYSQL_TCP_PORT=${MYSQL_PORT}
     volumes:
+      - ./osu.mysql.healthcheck.sh:/osu.mysql.healthcheck.sh:ro
       - ./osu.mysql.cnf:/etc/mysql/my.cnf:ro
-      - osu.mysql.vol:/docker-entrypoint-initdb.d/
+      - osu.mysql.init.vol:/docker-entrypoint-initdb.d/
     depends_on:
       osu.mysql.dl:
         condition: service_completed_successfully
     healthcheck:
-      test: [ "CMD", "mysqladmin", "ping", "--silent" ]
+      test: [ "CMD", "/bin/sh", "/osu.mysql.healthcheck.sh" ]
       interval: 3s
-      timeout: 3s
-      retries: 5
+      timeout: 15s
+      retries: 500
     ports:
       - ${MYSQL_PORT}:${MYSQL_PORT}
     expose:
@@ -64,13 +65,18 @@ services:
       dockerfile: osu.files.Dockerfile
       args:
         - FILES_URL=${FILES_URL}
-        - WORKDIR=/osu.files
+        - WORKDIR=/var/lib/osu/osu.files
+    healthcheck:
+      # Test if SERVICE_HEALTHY is 1
+      test: [ "CMD", "/bin/sh", "/osu.files.healthcheck.sh"  ]
+      interval: 3s
+      timeout: 15s
+      retries: 500
     volumes:
-      - osu.files.vol:/osu.files
+      - ./osu.files.healthcheck.sh:/osu.files.healthcheck.sh:ro
+      - /var/lib/osu/osu.files:/var/lib/osu/osu.files
     profiles:
       - files
 
 volumes:
-  osu.mysql.vol:
-  osu.mysql.dl.vol:
-  osu.files.vol:
+  osu.mysql.init.vol:

--- a/osu.files.healthcheck.sh
+++ b/osu.files.healthcheck.sh
@@ -1,0 +1,11 @@
+# Checks the state of the files download & extraction
+# Exit 0 if the download & extraction is done, else 1
+
+# If there's no matching processlist, then it's done.
+sleep 5 # Sleep is necessary just in case we're starting up
+
+if ! (pgrep '^tar*' || pgrep '^wget*'); then
+  exit 0
+else
+  exit 1
+fi

--- a/osu.mysql.dl.entrypoint.sh
+++ b/osu.mysql.dl.entrypoint.sh
@@ -6,7 +6,7 @@ DIR_NAME="$(basename "$DB_URL" .tar.bz2)"
 TAR_PATH=./"$TAR_NAME"
 DIR_PATH=./"$DIR_NAME"
 
-MYSQL_INIT_PATH=../osu.mysql
+MYSQL_INIT_PATH=../osu.mysql.init
 if [ -d "$MYSQL_INIT_PATH" ]; then
   rm "$MYSQL_INIT_PATH"/*
 fi
@@ -38,7 +38,7 @@ fi
 
 # Here, we guarantee that we have our .sql in $DIR_PATH
 # We move the sql files to our MySQL init path
-echo Moving Files to MySQL Initialization Directory
+echo Moving Files to MySQL Initialization Directory "$MYSQL_INIT_PATH"
 if [ "$OSU_BEATMAP_DIFFICULTY" = "1" ]; then cp "$DIR_PATH"/osu_beatmap_difficulty.sql "$MYSQL_INIT_PATH"/; fi
 if [ "$OSU_BEATMAPS" = "1" ]; then cp "$DIR_PATH"/osu_beatmaps.sql "$MYSQL_INIT_PATH"/; fi
 if [ "$OSU_BEATMAPSETS" = "1" ]; then cp "$DIR_PATH"/osu_beatmapsets.sql "$MYSQL_INIT_PATH"/; fi

--- a/osu.mysql.healthcheck.sh
+++ b/osu.mysql.healthcheck.sh
@@ -1,0 +1,6 @@
+# Checks the state of the importing.
+# Exit 0 if the import is done, else 1
+
+# If there's no matching processlist, then it's done.
+sleep 10;  # Sleep is necessary to ensure that the initialization has started.
+[ -z "$(mysql -u root -pp@ssw0rd1 -e "SELECT state FROM information_schema.processlist WHERE db='osu'")" ] && exit 0 || exit 1

--- a/scripts/get_maps.sh
+++ b/scripts/get_maps.sh
@@ -93,12 +93,12 @@ docker exec osu.files mkdir -p "$OUTPUT_FILES_DIR" || exit 1
 docker cp "$FILELIST_PATH" osu.files:"$FILELIST_PATH" || exit 1
 
 # Loop through filelist.txt and copy files to OUTPUT_DIR
-#   Retrieve <OSU_FILES_DIRNAME> /in osu.files/<OSU_FILES_DIRNAME>/*.osu
+#   Retrieve <OSU_FILES_DIRNAME> /in /var/lib/osu/osu.files/<OSU_FILES_DIRNAME>/*.osu
 OSU_FILES_DIRNAME=$(basename "$(docker exec osu.files sh -c 'echo $FILES_URL')" .tar.bz2)
 docker exec osu.files sh -c \
   '
   while read beatmap_id;
-    do cp /osu.files/'"$OSU_FILES_DIRNAME"'/"$beatmap_id".osu '"$OUTPUT_FILES_DIR"'/"$beatmap_id".osu; >> /dev/null 2>&1;
+    do cp /var/lib/osu/osu.files/'"$OSU_FILES_DIRNAME"'/"$beatmap_id".osu '"$OUTPUT_FILES_DIR"'/"$beatmap_id".osu; >> /dev/null 2>&1;
     [ $? ] || echo "Beatmap ID $beatmap_id cannot be found in osu.files";
     done < '"$FILELIST_PATH"';
   '

--- a/scripts/get_maps.sh
+++ b/scripts/get_maps.sh
@@ -58,22 +58,15 @@ fi
 # Check that osu.mysql and osu.files services are up
 echo "Checking that osu.mysql and osu.files services are up..."
 echo -n "osu.mysql: "
-if docker ps --format '{{.Names}}' | grep -q 'osu.mysql'; then
+if docker ps --filter "health=healthy" --filter "name=osu.mysql"; then
   echo -e "\e[32mOK\e[0m"
-  echo -e "\e[33mAdditionaly Check that osu.mysql has completed initialization\e[0m"
-  while ! docker logs osu.mysql 2>&1 | grep -q "MySQL init process done. Ready for start up."; do
-    echo -en "\e[33mWaiting for initialization... \e[0m"
-    echo -e "\e[34m Log: $(docker logs osu.mysql 2>&1 | tail -1)\e[0m"
-    sleep 5
-  done
-  echo -e "\e[32mosu.mysql has completed initialization\e[0m"
 else
   echo -e "\e[31mNOT RUNNING!\e[0m"
   exit 1
 fi
 
 echo -n "osu.files: "
-if docker ps --format '{{.Names}}' | grep -q 'osu.files'; then
+if docker ps --filter "health=healthy" --filter "name=osu.files"; then
   echo -e "\e[32mOK\e[0m"
 else
   echo -e "\e[31mNOT RUNNING!\e[0m"


### PR DESCRIPTION
# Major Changes
- Implements a working healthcheck for `osu.mysql` and `osu.files`. So it's now not necessary to externally check the status of importing and extraction

This is done by checking the processes, and seeing if they are done.
- For `osu.mysql` we check if the importing to `osu` db is still in progress
- For `osu.files` we check if the dling & extraction is still in progress via `pgrep`