### PR TITLE
Fix `get_maps` executing too quickly upon MySQL initialization

### DIFF
--- a/.env
+++ b/.env
@@ -4,7 +4,7 @@ MYSQL_PORT=3307
 
 # Double check with data.ppy.sh if it exists.
 DB_URL=https://data.ppy.sh/2023_08_01_performance_catch_top_1000.tar.bz2
-FILES_URL=https://data.ppy.sh/2023_08_01_osu_files.tar.bz2 
+FILES_URL=https://data.ppy.sh/2023_08_01_osu_files.tar.bz2
 
 # Sorted By File Size, Largest First. 0 to exclude, 1 to include.
 # beatmap_id,mode,mods,attrib_id,value

--- a/.env
+++ b/.env
@@ -4,7 +4,7 @@ MYSQL_PORT=3307
 
 # Double check with data.ppy.sh if it exists.
 DB_URL=https://data.ppy.sh/2023_08_01_performance_catch_top_1000.tar.bz2
-FILES_URL=https://data.ppy.sh/2023_08_01_osu_files.tar.bz2
+FILES_URL=https://data.ppy.sh/2023_08_01_osu_files.tar.bz2 
 
 # Sorted By File Size, Largest First. 0 to exclude, 1 to include.
 # beatmap_id,mode,mods,attrib_id,value


### PR DESCRIPTION
As mentioned in the title, the `get_maps` was executing too quickly, so it breaks our CI/CD non-deterministically.

We solved this by retrying the query a few times (5 times over 10s).

However, it's a bit problematic that we don't discern between a bad query and a slow start. But I don't think it's common enough to be an issue for now.